### PR TITLE
Correctly trim tags when filtering

### DIFF
--- a/js/grid.js
+++ b/js/grid.js
@@ -149,7 +149,7 @@ $( function() {
         var tags = $(this).find('.widget-tags').html();
         tags = tags.split(',');
         for (var i = 0; i < tags.length; i++) {
-          tagBool = tagBool || (tags[i] == tagVal);
+          tagBool = tagBool || (tags[i].trim() == tagVal);
         }
       }
 


### PR DESCRIPTION
This PR fixes a bug where widgets with more than 1 tag are not correctly filtered.
See for example filtering by tag `audio`, where there should be 1 element, nothing is showed.

